### PR TITLE
fix: set correct xml version

### DIFF
--- a/index.js
+++ b/index.js
@@ -63,7 +63,7 @@ function toXml (files) {
     let res = {
         _declaration: {
             _attributes: {
-                version: 1.0,
+                version: '1.0',
                 encoding: 'utf-8'
             }
         },


### PR DESCRIPTION
Hello,currently XML is generated with `<?xml version="1" encoding="utf-8"?>` which is no valid XML and breaks my sonar-scanner run with a message like 

> ERROR: Error during parsing of generic test execution report '/builds/project-0/coverage/sonar.xml'. Look at the SonarQube documentation to know the expected XML format.

I have provided a small fix for this.
